### PR TITLE
JC-1 - Añadiendo ws server

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install -g typescript
 
 --- 
 
-### Setup de en Docker para el servidor
+## DEV Setup
 
 Ubicados en el siguiente directorio: `<repo>/server/` podemos seguir estas intrucciones para hacer el setup.
 
@@ -45,10 +45,10 @@ npm run docker:stop
 Para eliminar la imagen de docker:
 
 ```
-npm run docker:rm
+npm run docker:image:rm
 ```
 ---
-Para correr los tests:
+## Test
 
 ```
 npm run test

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+logs

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -7,4 +7,4 @@ COPY . .
 RUN npm install
 RUN npm install -g typescript
 CMD ["npm", "run", "start:dev"]
-EXPOSE 3000
+EXPOSE 3000 3500

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,10 +9,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^4.18.2"
+        "express": "^4.18.2",
+        "ws": "^8.13.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.17",
+        "@types/ws": "^8.5.5",
         "nodemon": "^2.0.22",
         "ts-node": "^10.9.1"
       }
@@ -162,6 +164,15 @@
       "dev": true,
       "dependencies": {
         "@types/mime": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
+      "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
+      "dev": true,
+      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -1229,6 +1240,26 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -1379,6 +1410,15 @@
       "dev": true,
       "requires": {
         "@types/mime": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/ws": {
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
+      "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
+      "dev": true,
+      "requires": {
         "@types/node": "*"
       }
     },
@@ -2153,6 +2193,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
+    "ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "requires": {}
     },
     "yn": {
       "version": "3.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -15,10 +15,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "ws": "^8.13.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",
+    "@types/ws": "^8.5.5",
     "nodemon": "^2.0.22",
     "ts-node": "^10.9.1"
   }

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
     "docker:image": "docker build -f Dockerfile -t jdcamacho/nube-server .",
     "docker:cnt:unix": "docker run -t -p 3000:3000 -p 3500:3500 -d -v $(pwd):/usr/app/server --name nube-server jdcamacho/nube-server",
     "docker:cnt:pshell": "docker run -t -p 3000:3000 -p 3500:3500 -d -v ${PWD}:/usr/app/server --name nube-server jdcamacho/nube-server",
-    "docker:cnt:rm": "docker image rm -f jdcamacho/nube-server"
+    "docker:image:rm": "docker image rm -f jdcamacho/nube-server"
   },
   "author": "",
   "license": "ISC",

--- a/server/src/http/controllers/index.ts
+++ b/server/src/http/controllers/index.ts
@@ -1,0 +1,13 @@
+import { logger } from "../../utils/logger";
+import * as constants from '../../utils/constants';
+
+export const listen = () => 
+    logger.info(`Server app listening on port ${constants.PORTS.HTTP}`)
+
+export const ping = (req: any, res: any) => 
+    res.send('pong');
+
+export const root = (req: any, res: any) => { 
+    logger.info("Connection detected");
+    res.send('Helloo Worlad!');
+};

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -1,0 +1,12 @@
+import { logger } from '../utils/logger';
+import express from 'express';
+
+import * as constants from '../utils/constants';
+import * as controllers from './controllers';
+export const app = express();
+
+export const startHttpServer = () => {
+    app.get(constants.HTTP_PATHS.ROOT, (req, res) => controllers.root(req, res));
+    app.get(constants.HTTP_PATHS.TEST, (req, res) => controllers.ping(req, res));
+    app.listen(constants.PORTS.HTTP, () => controllers.listen());
+}

--- a/server/src/server.test.ts
+++ b/server/src/server.test.ts
@@ -1,9 +1,28 @@
 import request from 'supertest';
-const ENDPOINT = 'http://localhost:3500';
+import WebSocket from "ws";
+import * as constants from './utils/constants'
+import { delay, waitForWebSocketClient } from './utils';
 
-describe('server', () => {
-    it('tests /ping endpoint - positive test', async () => {
-        const response = await request(ENDPOINT).get("/ping");
+describe('http server', () => {
+    test('it should return "pong"', async () => {
+        const response = await request(constants.ENDPOINTS.DEV.HTTP).get(constants.HTTP_PATHS.TEST);
         expect(response.text).toEqual(response.text);
     });
-})
+});
+
+describe('ws server', () => {
+    test('it should return the expected test message', async () => {
+        let expectedMsg: any;
+        const testMsg = "Test message";
+        const client = new WebSocket(constants.ENDPOINTS.DEV.WS);
+        await waitForWebSocketClient(client);
+        client.on("message", (data) => expectedMsg = data);
+        client.send(testMsg);
+        await new Promise(async resolve => {
+            while (!expectedMsg) await delay(1000);
+            resolve(true);
+        });
+        client.close();
+        expect(expectedMsg.toString()).toBe(testMsg);
+   });
+});

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -9,8 +9,8 @@ const app = express();
 const wss = new ws.Server({ port: WS_PORT });
 
 app.get('/', (req, res) => {
-    logger.info("");
-    res.send('Hello World!');
+    logger.info("Connection detected");
+    res.send('Helloo World!');
 });
 
 app.get('/ping', (req, res) => {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -5,13 +5,15 @@ import fs from 'fs';
 
 const PORT = 3000;
 const WS_PORT = 3500;
-const LOG_FILE = path.join(__dirname, "logs/texts.log");
+const LOG_FOLDER = path.join(__dirname, "../", "/logs")
+const LOG_FILE = path.join(LOG_FOLDER, "/texts.log");
 
 const app = express();
 const wss = new ws.Server({ port: WS_PORT });
 
 app.get('/', (req, res) => {
-    res.send('Hello World!');
+    if(req.query.logger) addLineToFile(`[http]:${req.query.logger.toString()}`);
+    res.send('Helslo World!');
 });
 
 app.listen(PORT, () => {
@@ -25,19 +27,20 @@ wss.on('connection', (ws: any) => {
     });
 
     ws.on('text', (data: string) => {
-        addLineToFile(data);
+        addLineToFile(`[ws]:${data}`);
     });
 });
 
 const addLineToFile = (text: string): void => {
+    if(!fs.existsSync(LOG_FOLDER)) createLogFolder();
     if(!fs.existsSync(LOG_FILE)) createLogFile();
     fs.appendFileSync(LOG_FILE, parseText(text));
 }
 
 const parseText = (text: string): string => {
-    return `${new Date()}: ${text}`;
+    return `${new Date()}: ${text}\n`;
 };
 
 const createLogFile = () => fs.writeFileSync(LOG_FILE, "");
 
-addLineToFile("example");
+const createLogFolder = () => fs.mkdirSync(LOG_FOLDER);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,11 +1,43 @@
 import express from 'express';
+import path from 'path';
+import ws from 'ws';
+import fs from 'fs';
+
+const PORT = 3000;
+const WS_PORT = 3500;
+const LOG_FILE = path.join(__dirname, "logs/texts.log");
+
 const app = express();
-const port = 3000;
+const wss = new ws.Server({ port: WS_PORT });
 
 app.get('/', (req, res) => {
     res.send('Hello World!');
 });
 
-app.listen(port, () => {
-    console.log(`Example app listening on port ${port}`);
+app.listen(PORT, () => {
+    console.log(`Example app listening on port ${PORT}`);
 });
+
+wss.on('connection', (ws: any) => {
+    
+    ws.on('camera', (data: any) => {
+
+    });
+
+    ws.on('text', (data: string) => {
+        addLineToFile(data);
+    });
+});
+
+const addLineToFile = (text: string): void => {
+    if(!fs.existsSync(LOG_FILE)) createLogFile();
+    fs.appendFileSync(LOG_FILE, parseText(text));
+}
+
+const parseText = (text: string): string => {
+    return `${new Date()}: ${text}`;
+};
+
+const createLogFile = () => fs.writeFileSync(LOG_FILE, "");
+
+addLineToFile("example");

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -3,8 +3,8 @@ import path from 'path';
 import ws from 'ws';
 import fs from 'fs';
 
-const PORT = 3000;
-const WS_PORT = 3500;
+const PORT = 3500;
+const WS_PORT = 3000;
 const LOG_FOLDER = path.join(__dirname, "../", "/logs")
 const LOG_FILE = path.join(LOG_FOLDER, "/texts.log");
 
@@ -13,7 +13,7 @@ const wss = new ws.Server({ port: WS_PORT });
 
 app.get('/', (req, res) => {
     if(req.query.logger) addLineToFile(`[http]:${req.query.logger.toString()}`);
-    res.send('Helslo World!');
+    res.send('Hello World!');
 });
 
 app.listen(PORT, () => {
@@ -21,19 +21,21 @@ app.listen(PORT, () => {
 });
 
 wss.on('connection', (ws: any) => {
-    
-    ws.on('camera', (data: any) => {
+    addLineToFile(`[ws]:Conexion establecida`);
 
-    });
-
-    ws.on('text', (data: string) => {
+    ws.on('message', (data: any) => {
         addLineToFile(`[ws]:${data}`);
     });
+
+    ws.on('close', () => {
+        addLineToFile(`[ws]:Desconectado`);
+    })
 });
 
 const addLineToFile = (text: string): void => {
     if(!fs.existsSync(LOG_FOLDER)) createLogFolder();
     if(!fs.existsSync(LOG_FILE)) createLogFile();
+    console.log(parseText(text));
     fs.appendFileSync(LOG_FILE, parseText(text));
 }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,29 +1,7 @@
-import express from 'express';
-import ws from 'ws';
-import { logger } from './utils/logger';
+import { startHttpServer } from "./http/server";
+import { startWebsocketServer } from "./websocket/server";
 
-const PORT = 3000;
-const WS_PORT = 3500;
-
-const app = express();
-const wss = new ws.Server({ port: WS_PORT });
-
-app.get('/', (req, res) => {
-    logger.info("Connection detected");
-    res.send('Helloo World!');
-});
-
-app.get('/ping', (req, res) => {
-    res.send('pong');
-});
-
-app.listen(PORT, () => {
-    logger.info(`Server app listening on port ${PORT}`);
-});
-
-wss.on('connection', (ws: any) => {
-    logger.info(`[ws] Connection detected`);
-    ws.on('message', (data: string) => {
-        logger.info(`[ws] ${data}`);
-    });
-});
+(function(){
+    startHttpServer();
+    startWebsocketServer();
+})();

--- a/server/src/utils/constants.ts
+++ b/server/src/utils/constants.ts
@@ -1,0 +1,16 @@
+export const PORTS = {
+    WS: 3500,
+    HTTP: 3000
+};
+const DEV_ENDPOINTS = {
+    WS: `ws://localhost:${PORTS.WS}`,
+    HTTP: `http://localhost:${PORTS.HTTP}`
+}
+export const ENDPOINTS = {
+    DEV: DEV_ENDPOINTS
+}
+
+export const HTTP_PATHS = {
+    ROOT: "/",
+    TEST: "/ping"
+}

--- a/server/src/utils/index.ts
+++ b/server/src/utils/index.ts
@@ -1,0 +1,7 @@
+export const delay = (sleepTime: number) => new Promise((resolve) => setTimeout(() => {resolve(true)}, sleepTime));
+export const waitForWebSocketClient = async (client: any) => {
+    await new Promise(async resolve => {
+        while (client.readyState != client.OPEN) await delay(1000);
+        resolve(true);
+    })
+};

--- a/server/src/utils/logger.ts
+++ b/server/src/utils/logger.ts
@@ -26,9 +26,8 @@ winston.addColors(colors)
 
 const format = winston.format.combine(
   winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss:ms' }),
-  winston.format.colorize({ all: true }),
   winston.format.printf(
-    (info) => `${info.timestamp}${info.level}:${info.message}`,
+    (info) => `[${info.timestamp}][${info.level}]:${info.message}`,
   ),
 )
 

--- a/server/src/websocket/server.ts
+++ b/server/src/websocket/server.ts
@@ -1,0 +1,15 @@
+import { logger } from '../utils/logger';
+import * as constants from '../utils/constants';
+
+import ws from 'ws';
+export const wss = new ws.Server({ port: constants.PORTS.WS });
+
+export const startWebsocketServer = () => {
+    wss.on('connection', (ws: any) => {
+        logger.info(`[ws] Connection detected`);
+        ws.on('message', (data: string) => {
+            ws.send(data);
+            logger.info(`[ws] ${data}`);
+        });
+    });
+}


### PR DESCRIPTION
Organize un poco las carpetas, ahora la estructura es la siguiente:
- server: inicializa ambos servidores (http, ws)
  - http: donde esta la logica y las rutas http
    - controllers: donde esta la logica de las rutas
  - ws: donde esta la logica del servidor ws (hay que organizarlo mejor y tratar de hacer channels de esa manera podemos distribuir mejor la logica de cada funcion que queramos)

Hice un test para el servidor ws pero estaba pensando en mover este test y ponerlo en la carpeta ws al igual que el test para http, de esa manera podemos organizar mejor los test.

Trate de mover la definicion de las rutas a constant al igual que los puertos y los dev endpoint

Por ultimo añadi ambos puertos en el docker image y en el commando de los docker run